### PR TITLE
New route `/api/calculate/pp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,25 @@ v2 _**(tosu own api)**_
 - `/websocket/v2` - [response example](https://github.com/KotRikD/tosu/wiki/v2-websocket-api-response)
 - `/files/beatmap/{path}` - same as `/Songs/{path}`
 - `/files/skin/{path}` - similar as `/files/beatmap/{path}`, but for a skin
+
+api
+- `/api/calculate/pp` - Calculate pp for beatmap with custom data
+  - [Response example](https://github.com/KotRikD/tosu/wiki/api-calculate-pp-response-example)
+  - BY DEFAULT IT USES CURRENT BEATMAP (:))
+  - All parameters are optional
+  - `path` - Path to .osu file. Example: C:/osu/Songs/beatmap/file.osu
+  - `mode` - Osu = 0, Taiko = 1, Catch = 2, Mania = 3
+  - `mods` - Mods id. Example: 64 - DT
+  - `acc` - Accuracy % from 0 to 100
+  - `nGeki` - Amount of Geki (300g / MAX)
+  - `nKatu` - Amount of Katu (100k / 200)
+  - `n300` - Amount of 300
+  - `n100` - Amount of 100
+  - `n50` - Amount of 50
+  - `nMisses` - Amount of Misses
+  - `combo` - combo
+  - `passedObjects` - Sum of nGeki, nKatu, n300, n100, n50, nMisses
+  - `clockRate` - Map rate number. Example: 1.5 = DT
 ---
 
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,7 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@kotrikd/rosu-pp": "^0.10.0",
     "@tosu/common": "workspace:*",
     "ws": "^8.16.0"
   },

--- a/packages/server/router/index.ts
+++ b/packages/server/router/index.ts
@@ -1,4 +1,5 @@
-import { config } from '@tosu/common';
+import { Beatmap, Calculator } from '@kotrikd/rosu-pp';
+import { config, wLogger } from '@tosu/common';
 import path from 'path';
 
 import { HttpServer, getContentType, sendJson } from '../index';
@@ -29,8 +30,58 @@ export default function buildBaseApi(app: HttpServer) {
         });
     });
 
+    app.route('/api/calculate/pp', 'GET', (req, res) => {
+        try {
+            const query: any = req.query;
+
+            const osuInstances: any = Object.values(
+                req.instanceManager.osuInstances || {}
+            );
+            if (osuInstances.length < 1) {
+                res.statusCode = 500;
+                return sendJson(res, { error: 'not_ready' });
+            }
+
+            const { settings, menuData } = osuInstances[0].entities.getServices(
+                ['settings', 'menuData']
+            );
+
+            const beatmapFilePath =
+                query.path ||
+                path.join(
+                    settings.gameFolder,
+                    'Songs',
+                    menuData.Folder,
+                    menuData.Path
+                );
+
+            const parseBeatmap = new Beatmap({ path: beatmapFilePath });
+            const calculator = new Calculator();
+
+            const array = Object.keys(query || {});
+            for (let i = 0; i < array.length; i++) {
+                const key = array[i];
+                const value = query[key];
+
+                if (key in calculator && isFinite(+value))
+                    calculator[key](+value);
+            }
+
+            return sendJson(res, {
+                attributes: calculator.mapAttributes(parseBeatmap),
+                performance: calculator.performance(parseBeatmap)
+            });
+        } catch (error) {
+            wLogger.error(error);
+
+            return sendJson(res, {
+                error: (error as any).message
+            });
+        }
+    });
+
     app.route(/.*/, 'GET', (req, res) => {
-        const url = req.url || '/';
+        const url = req.pathname || '/';
         const folderPath =
             config.staticFolderPath ||
             path.join(path.dirname(process.execPath), 'static');

--- a/packages/server/router/v1.ts
+++ b/packages/server/router/v1.ts
@@ -22,7 +22,7 @@ export default function buildV1Api({
     });
 
     app.route(/\/Songs\/(?<filePath>.*)/, 'GET', (req, res) => {
-        const url = req.url || '/';
+        const url = req.pathname || '/';
 
         const osuInstances: any = Object.values(
             req.instanceManager.osuInstances || {}

--- a/packages/server/router/v2.ts
+++ b/packages/server/router/v2.ts
@@ -63,7 +63,7 @@ export default function buildV2Api({
     });
 
     app.route(/\/files\/beatmap\/(?<filePath>.*)/, 'GET', (req, res) => {
-        const url = req.url || '/';
+        const url = req.pathname || '/';
 
         const osuInstances: any = Object.values(
             req.instanceManager.osuInstances || {}
@@ -88,7 +88,7 @@ export default function buildV2Api({
     });
 
     app.route(/\/files\/skin\/(?<filePath>.*)/, 'GET', (req, res) => {
-        const url = req.url || '/';
+        const url = req.pathname || '/';
 
         const osuInstances: any = Object.values(
             req.instanceManager.osuInstances || {}

--- a/packages/server/utils/http.ts
+++ b/packages/server/utils/http.ts
@@ -5,6 +5,7 @@ export interface ExtendedIncomingMessage extends IncomingMessage {
     instanceManager: any;
     query: { [key: string]: string };
     params: { [key: string]: string };
+    pathname: string;
     getContentType: (text: string) => string;
     sendJson: (
         response: http.ServerResponse,
@@ -94,13 +95,13 @@ export class HttpServer {
     private handleNext(req: ExtendedIncomingMessage, res: http.ServerResponse) {
         const method = req.method || 'GET';
         const hostname = req.headers.host; // Hostname
-        const url = req.url || '/'; // URL
 
         const parsedURL = new URL(`http://${hostname}${req.url}`);
 
         // parse query parameters
         req.query = {};
         req.params = {};
+        req.pathname = parsedURL.pathname;
 
         parsedURL.searchParams.forEach(
             (value, key) => (req.query[key] = value)
@@ -133,7 +134,7 @@ export class HttpServer {
                     req.params[key] = value;
                 }
             } else if (typeof route.path == 'string')
-                routeExists = route.path == url;
+                routeExists = route.path == parsedURL.pathname;
 
             if (!routeExists) continue;
             return route.handler(req, res);

--- a/packages/server/utils/socket.ts
+++ b/packages/server/utils/socket.ts
@@ -75,17 +75,15 @@ export class Websocket {
             }
 
             if (this.clients.size > 0) {
-                this.clients.forEach((value, key) => {
-                    try {
-                        value.send(
-                            JSON.stringify(
-                                osuInstances[0][this.stateFunctionName](
-                                    this.instanceManager
-                                )
-                            )
-                        );
-                    } catch (error) {}
-                });
+                try {
+                    const message = JSON.stringify(
+                        osuInstances[0][this.stateFunctionName](
+                            this.instanceManager
+                        )
+                    );
+
+                    this.clients.forEach((client, key) => client.send(message));
+                } catch (error) {}
             }
 
             setTimeout(this.loop, config[this.pollRateFieldName]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
 
   packages/server:
     dependencies:
+      '@kotrikd/rosu-pp':
+        specifier: ^0.10.0
+        version: 0.10.0
       '@tosu/common':
         specifier: workspace:*
         version: link:../common


### PR DESCRIPTION
`/api/calculate/pp` - Calculate pp for beatmap with custom data
- [Response example](https://github.com/KotRikD/tosu/wiki/api-calculate-pp-response-example)
- All parameters are optional
- `path` - Path to .osu file. Example: C:/osu/Songs/beatmap/file.osu
- `mode` - Osu = 0, Taiko = 1, Catch = 2, Mania = 3
- `mods` - Mods id. Example: 64 - DT
- `acc` - Accuracy % from 0 to 100
- `nGeki` - Amount of Geki (300g / MAX)
- `nKatu` - Amount of Katu (100k / 200)
- `n300` - Amount of 300
- `n100` - Amount of 100
- `n50` - Amount of 50
- `nMisses` - Amount of Misses
- `combo` - combo
- `passedObjects` - Sum of nGeki, nKatu, n300, n100, n50, nMisses
- `clockRate` - Map rate number. Example: 1.5 = DT