### PR TITLE
fix: optimize pattern scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 node_modules
 yarn-error.log
 static/
+.clangd
 package-lock.json
 config.ini
 tosu.exe

--- a/packages/tosu/src/objects/instanceManager/osuInstance.ts
+++ b/packages/tosu/src/objects/instanceManager/osuInstance.ts
@@ -248,8 +248,7 @@ export class OsuInstance {
                 this.isReady = true;
             } catch (exc) {
                 wLogger.error(
-                    `[${this.pid}] PATTERN SCANNING FAILED, TRYING ONE MORE TIME...`,
-                    exc
+                    `[${this.pid}] PATTERN SCANNING FAILED, TRYING ONE MORE TIME...`
                 );
                 wLogger.debug(exc);
                 this.emitter.emit('onResolveFailed', this.pid);

--- a/packages/tsprocess/src/process.ts
+++ b/packages/tsprocess/src/process.ts
@@ -86,6 +86,10 @@ export class Process {
         return ProcessUtils.readBuffer(this.handle, address, size);
     }
 
+    scanRegions(callback: (baseAddress: number, region: Buffer) => void) {
+        ProcessUtils.scanRegions(this.handle, callback);
+    }
+
     scanSync(
         pattern: string,
         refresh: boolean = false,


### PR DESCRIPTION
Scans each region for all not found patterns at one time instead of scanning all regions for one pattern.
More noticeable on low-end pc