### PR TITLE
Fix bug with retrieving beatmap data due to improper URL encoding

### DIFF
--- a/packages/server/utils/directories.ts
+++ b/packages/server/utils/directories.ts
@@ -23,7 +23,7 @@ export function directoryWalker({
 }) {
     let cleanedUrl;
     try {
-        cleanedUrl = decodeURI(pathname);
+        cleanedUrl = decodeURIComponent(pathname);
     } catch (error) {
         res.writeHead(404, {
             'Content-Type': getContentType('file.txt')
@@ -113,9 +113,10 @@ export function readDirectory(
 
         const html = folders.map((r) => {
             const slashAtTheEnd = getContentType(r) === '' ? '/' : '';
+
             return `<li><a href="${
                 url === '/' ? '' : url
-            }${r}${slashAtTheEnd}">${r}</a></li>`;
+            }${encodeURIComponent(r)}${slashAtTheEnd}">${r}</a></li>`;
         });
 
         return callback(


### PR DESCRIPTION
I'm using tosu in a personal project of mine, and when I tried to access map data for certain songs, it was giving me a 404 error. Funny. As it turns out, such directory names contained URL reserved characters such as "#", and since the server was just running `decodeURI()` on the whole URL, it wasn't treating such reserved characters LITERALLY.

Take this directory name for example: `1032511 Hino Isuka - #be_fortunate`

Obviously, the `#` is part of the song name, thus we want to treat it as a literal part of the resource name, instead of as a page locator tag. So I implemented `encodeURIComponent()` on each part of the URL, so that it would treat the # literally, encoding it as %23. :3