### PR TITLE
fix bad map id momentarily being sent when hitting panic button in tclient 

### DIFF
--- a/packages/tosu/src/api/utils/buildResult.ts
+++ b/packages/tosu/src/api/utils/buildResult.ts
@@ -1,3 +1,4 @@
+import { wLogger } from '@tosu/common/utils/logger';
 import path from 'path';
 
 import {
@@ -81,6 +82,8 @@ export const buildResult = (instanceManager: InstanceManager): ApiAnswer => {
         50: resultsScreenData.Hit50,
         0: resultsScreenData.HitMiss
     };
+
+    wLogger.info(`[${osuInstance.pid}] current mapid ${menuData.MapID}`);
 
     return {
         settings: {

--- a/packages/tosu/src/api/utils/buildResult.ts
+++ b/packages/tosu/src/api/utils/buildResult.ts
@@ -1,4 +1,3 @@
-import { wLogger } from '@tosu/common/utils/logger';
 import path from 'path';
 
 import {
@@ -82,8 +81,6 @@ export const buildResult = (instanceManager: InstanceManager): ApiAnswer => {
         50: resultsScreenData.Hit50,
         0: resultsScreenData.HitMiss
     };
-
-    wLogger.info(`[${osuInstance.pid}] current mapid ${menuData.MapID}`);
 
     return {
         settings: {

--- a/packages/tosu/src/entities/MenuData/index.ts
+++ b/packages/tosu/src/entities/MenuData/index.ts
@@ -55,7 +55,6 @@ export class MenuData extends AbstractEntity {
             const newMD5 = process.readSharpString(
                 process.readInt(beatmapAddr + 0x6c)
             );
-            this.pendingMD5 = newMD5;
 
             // [[Beatmap] + 0x90]
             const newPath = process.readSharpString(

--- a/packages/tosu/src/entities/MenuData/index.ts
+++ b/packages/tosu/src/entities/MenuData/index.ts
@@ -61,11 +61,6 @@ export class MenuData extends AbstractEntity {
                 process.readInt(beatmapAddr + 0x90)
             );
 
-            // //  [[Beatmap] + 0x68]
-            const newBackgroundFilename = process.readSharpString(
-                process.readInt(beatmapAddr + 0x68)
-            );
-
             if (newMD5 === this.previousMD5 || !newPath.endsWith('.osu')) {
                 return;
             }
@@ -84,12 +79,6 @@ export class MenuData extends AbstractEntity {
             // MD5 hasn't changed in over NEW_MAP_COMMIT_DELAY, commit to new map
             this.MD5 = newMD5;
             this.Path = newPath;
-            this.BackgroundFilename = newBackgroundFilename;
-
-            //  [Beatmap] + 0xC8
-            this.MapID = process.readInt(beatmapAddr + 0xc8);
-            //  [Beatmap] + 0xCC
-            this.SetID = process.readInt(beatmapAddr + 0xcc);
 
             // [Base - 0x33]
             this.MenuGameMode = process.readPointer(baseAddr - 0x33);
@@ -127,6 +116,10 @@ export class MenuData extends AbstractEntity {
             this.AudioFilename = process.readSharpString(
                 process.readInt(beatmapAddr + 0x64)
             );
+            // //  [[Beatmap] + 0x68]
+            this.BackgroundFilename = process.readSharpString(
+                process.readInt(beatmapAddr + 0x68)
+            );
             //  [[Beatmap] + 0x78]
             this.Folder = process.readSharpString(
                 process.readInt(beatmapAddr + 0x78)
@@ -143,6 +136,10 @@ export class MenuData extends AbstractEntity {
             this.Difficulty = process.readSharpString(
                 process.readInt(beatmapAddr + 0xac)
             );
+            //  [Beatmap] + 0xC8
+            this.MapID = process.readInt(beatmapAddr + 0xc8);
+            //  [Beatmap] + 0xCC
+            this.SetID = process.readInt(beatmapAddr + 0xcc);
             // unknown, unsubmitted, pending/wip/graveyard, unused, ranked, approved, qualified
             //  [Beatmap] + 0x12C
             this.RankedStatus = process.readInt(beatmapAddr + 0x12c);


### PR DESCRIPTION
follow-up to #109

tosu has regressed compared to gosu wherein it still occasionally returns the wrong map ID when certain actions occur on the tournament client (e.g. pressing panic button when gameplay starts and client #0 hasn't loaded in).
A number of tournament overlays update pick/bans using current map ID, and this flip-flopping of map IDs can mess up autopick. Of course, it's fairly trivial to fix this on the overlay side, but a regression is a regression.