### PR TITLE
ignore lazer tournament client

### DIFF
--- a/packages/tosu/src/objects/instanceManager/instanceManager.ts
+++ b/packages/tosu/src/objects/instanceManager/instanceManager.ts
@@ -48,6 +48,12 @@ export class InstanceManager {
 
                 const osuInstance = new OsuInstance(processId);
                 const cmdLine = osuInstance.process.getProcessCommandLine();
+
+                if (cmdLine.includes('--tournament')) {
+                    // skip the lazer tournament client
+                    continue;
+                }
+
                 if (cmdLine.includes('-spectateclient')) {
                     const ipcId = cmdLine.split(' ').at(-2);
 


### PR DESCRIPTION
tosu gets stuck if the osu lazer tournament client is running alongside stable tournament client. 

this PR adds a check to ignore an osu!.exe process if it contains the `--tournament` flag used to launch lazer in tclient mode