### PR TITLE
feat: add KeyOverlay to tournament clients

### DIFF
--- a/packages/tosu/src/api/utils/buildResult.ts
+++ b/packages/tosu/src/api/utils/buildResult.ts
@@ -350,6 +350,7 @@ const buildTourneyData = (
                         unstableRate: gamePlayData.UnstableRate,
                         hitErrorArray: gamePlayData.HitErrors
                     },
+                    keyOverlay: gamePlayData.KeyOverlay,
                     mods: {
                         num: currentMods,
                         str: getOsuModsString(currentMods)


### PR DESCRIPTION
Implements KeyOverlay to tournament clients. I didn't check it in real case, because I don't have osu! supporter.

Resolves #160