### PR TITLE
Update delay & HitErrors & improves

### DIFF
--- a/packages/server/assets/homepage.html
+++ b/packages/server/assets/homepage.html
@@ -56,7 +56,7 @@
     </div>
   </main>
   <footer>
-    <span>created by </span><a href="https://osuck.net/" target="_blank">cyperdark</a>
+    <span>created by <a href="https://kotrik.ru/" target="_blank">KotRik</a>, <a href="https://github.com/xxCherry" target="_blank">Cherry</a> & <a href="https://osuck.net/" target="_blank">cyperdark</a></span>
   </footer>
   <script src="/assets/homepage.js" defer></script>
 </body>

--- a/packages/tosu/src/entities/AbstractEntity/index.ts
+++ b/packages/tosu/src/entities/AbstractEntity/index.ts
@@ -28,4 +28,13 @@ export abstract class AbstractEntity {
     resetReportCount(id: string | number) {
         this.errorsCount[id] = 0;
     }
+
+    preventThrow(callback) {
+        try {
+            const result = callback();
+            return result;
+        } catch (error) {
+            return error as Error;
+        }
+    }
 }

--- a/packages/tosu/src/entities/AllTimesData/index.ts
+++ b/packages/tosu/src/entities/AllTimesData/index.ts
@@ -61,21 +61,12 @@ export class AllTimesData extends AbstractEntity {
                 'canRunSlowlyAddr'
             ]);
 
-            const skinOsuAddr = process.readInt(skinDataAddr + 0x7);
-            if (skinOsuAddr === 0) {
-                return;
-            }
-            const skinOsuBase = process.readInt(skinOsuAddr);
-
             // [Status - 0x4]
             this.Status = process.readPointer(statusPtr);
             // [MenuMods + 0x9]
             this.MenuMods = process.readPointer(menuModsPtr);
             // ChatChecker - 0x20
             this.ChatStatus = process.readByte(chatCheckerAddr - 0x20);
-            this.SkinFolder = process.readSharpString(
-                process.readInt(skinOsuBase + 0x44)
-            );
             this.IsWatchingReplay = process.readByte(
                 process.readInt(canRunSlowlyAddr + 0x46)
             );
@@ -95,6 +86,16 @@ export class AllTimesData extends AbstractEntity {
                     ) + 0xc
                 )
             );
+
+            const skinOsuAddr = process.readInt(skinDataAddr + 0x7);
+            if (skinOsuAddr !== 0) {
+                const skinOsuBase = process.readInt(skinOsuAddr);
+
+                this.SkinFolder = process.readSharpString(
+                    process.readInt(skinOsuBase + 0x44)
+                );
+                return;
+            }
 
             if (
                 !this.osuInstance.isTourneyManager &&

--- a/packages/tosu/src/entities/BeatmapPpData/index.ts
+++ b/packages/tosu/src/entities/BeatmapPpData/index.ts
@@ -1,4 +1,4 @@
-import { wLogger } from '@tosu/common';
+import { config, wLogger } from '@tosu/common';
 import fs from 'fs';
 import { Beatmap as ParsedBeatmap } from 'osu-classes';
 import { BeatmapDecoder } from 'osu-parsers';
@@ -213,13 +213,17 @@ export class BeatmapPPData extends AbstractEntity {
             this.PerformanceAttributes = fcPerformance;
             this.clockRate = attributes.clockRate;
 
-            const ppAcc = {};
-            for (const acc of [100, 99, 98, 97, 96, 95]) {
-                const calculate = new rosu.Performance({
-                    mods: currentMods,
-                    accuracy: acc
-                }).calculate(fcPerformance);
-                ppAcc[acc] = fixDecimals(calculate.pp);
+            if (config.calculatePP) {
+                const ppAcc = {};
+                for (const acc of [100, 99, 98, 97, 96, 95]) {
+                    const calculate = new rosu.Performance({
+                        mods: currentMods,
+                        accuracy: acc
+                    }).calculate(fcPerformance);
+                    ppAcc[acc] = fixDecimals(calculate.pp);
+
+                    calculate.free();
+                }
 
                 this.ppAcc = ppAcc as any;
             }

--- a/packages/tosu/src/entities/BeatmapPpData/index.ts
+++ b/packages/tosu/src/entities/BeatmapPpData/index.ts
@@ -127,10 +127,12 @@ export class BeatmapPPData extends AbstractEntity {
             peak: 0.0,
             hitWindow: 0.0
         };
-        this.currAttributes.stars = 0.0;
-        this.currAttributes.pp = 0.0;
-        this.currAttributes.maxThisPlayPP = 0.0;
-        this.currAttributes.fcPP = 0.0;
+        this.currAttributes = {
+            stars: 0.0,
+            pp: 0.0,
+            maxThisPlayPP: 0.0,
+            fcPP: 0.0
+        };
         this.timings = {
             firstObj: 0,
             full: 0
@@ -153,10 +155,12 @@ export class BeatmapPPData extends AbstractEntity {
     }
 
     resetCurrentAttributes() {
-        this.currAttributes.stars = 0.0;
-        this.currAttributes.pp = 0.0;
-        this.currAttributes.maxThisPlayPP = 0.0;
-        this.currAttributes.fcPP = 0.0;
+        this.currAttributes = {
+            stars: 0.0,
+            pp: 0.0,
+            maxThisPlayPP: 0.0,
+            fcPP: 0.0
+        };
     }
 
     getCurrentBeatmap() {

--- a/packages/tosu/src/entities/GamePlayData/index.ts
+++ b/packages/tosu/src/entities/GamePlayData/index.ts
@@ -461,7 +461,7 @@ export class GamePlayData extends AbstractEntity {
         } catch (exc) {
             this.reportError(
                 'GD(updateHitErrors)',
-                10,
+                50,
                 `GD(updateHitErrors) ${(exc as any).message}`
             );
             wLogger.debug(exc);

--- a/packages/tosu/src/entities/GamePlayData/index.ts
+++ b/packages/tosu/src/entities/GamePlayData/index.ts
@@ -657,7 +657,7 @@ export class GamePlayData extends AbstractEntity {
         }
 
         if (fcPerformance) {
-            beatmapPpData.updateFcPP(fcPerformance.pp);
+            beatmapPpData.currAttributes.fcPP = fcPerformance.pp;
         }
 
         this.previousPassedObjects = passedObjects;

--- a/packages/tosu/src/entities/GamePlayData/index.ts
+++ b/packages/tosu/src/entities/GamePlayData/index.ts
@@ -446,12 +446,16 @@ export class GamePlayData extends AbstractEntity {
             const items = process.readInt(base + 0x4);
             const size = process.readInt(base + 0xc);
 
+            const errors: Array<number> = [];
+
             for (let i = this.HitErrors.length - 1; i < size; i++) {
                 const current = items + leaderStart + 0x4 * i;
                 const error = process.readInt(current);
 
-                this.HitErrors.push(error);
+                errors.push(error);
             }
+
+            this.HitErrors = errors;
 
             this.resetReportCount('GD(updateHitErrors)');
         } catch (exc) {

--- a/packages/tosu/src/entities/MenuData/index.ts
+++ b/packages/tosu/src/entities/MenuData/index.ts
@@ -65,7 +65,11 @@ export class MenuData extends AbstractEntity {
                 return;
             }
 
-            if (this.pendingMD5 !== newMD5) {
+            if (
+                this.pendingMD5 !== newMD5 &&
+                (this.osuInstance.isTourneySpectator ||
+                    this.osuInstance.isTourneyManager)
+            ) {
                 this.mapChangeTime = performance.now();
                 this.pendingMD5 = newMD5;
 

--- a/packages/tosu/src/entities/MenuData/index.ts
+++ b/packages/tosu/src/entities/MenuData/index.ts
@@ -72,7 +72,11 @@ export class MenuData extends AbstractEntity {
                 return;
             }
 
-            if (performance.now() - this.mapChangeTime < NEW_MAP_COMMIT_DELAY) {
+            if (
+                performance.now() - this.mapChangeTime < NEW_MAP_COMMIT_DELAY &&
+                (this.osuInstance.isTourneySpectator ||
+                    this.osuInstance.isTourneyManager)
+            ) {
                 return;
             }
 

--- a/packages/tosu/src/entities/MenuData/index.ts
+++ b/packages/tosu/src/entities/MenuData/index.ts
@@ -48,7 +48,7 @@ export class MenuData extends AbstractEntity {
             const beatmapAddr = process.readPointer(baseAddr - 0xc);
             if (beatmapAddr === 0) {
                 wLogger.debug('MD(updateState) beatmapAddr is 0');
-                return;
+                return 'not-ready';
             }
 
             // [[Beatmap] + 0x6C]

--- a/packages/tosu/src/entities/ResultsScreenData/index.ts
+++ b/packages/tosu/src/entities/ResultsScreenData/index.ts
@@ -187,7 +187,6 @@ export class ResultsScreenData extends AbstractEntity {
                 nGeki: this.HitGeki
             };
 
-            wLogger.debug('result-screen-start');
             const curPerformance = new rosu.Performance(scoreParams).calculate(
                 currentBeatmap
             );
@@ -196,7 +195,6 @@ export class ResultsScreenData extends AbstractEntity {
                 misses: 0,
                 accuracy: this.Accuracy
             }).calculate(curPerformance);
-            wLogger.debug('result-screen-update');
 
             this.pp = curPerformance.pp;
             this.fcPP = fcPerformance.pp;

--- a/packages/tosu/src/entities/ResultsScreenData/index.ts
+++ b/packages/tosu/src/entities/ResultsScreenData/index.ts
@@ -82,13 +82,13 @@ export class ResultsScreenData extends AbstractEntity {
             );
             if (rulesetAddr === 0) {
                 wLogger.debug('RSD(updateState) rulesetAddr is zero');
-                return;
+                return 'not-ready';
             }
 
             const resultScreenBase = process.readInt(rulesetAddr + 0x38);
             if (resultScreenBase === 0) {
                 wLogger.debug('RSD(updateState) resultScreenBase is zero');
-                return;
+                return 'not-ready';
             }
 
             // OnlineId   int64   `mem:"[Ruleset + 0x38] + 0x4"`

--- a/packages/tosu/src/objects/instanceManager/osuInstance.ts
+++ b/packages/tosu/src/objects/instanceManager/osuInstance.ts
@@ -249,7 +249,12 @@ export class OsuInstance {
             try {
                 allTimesData.updateState();
                 settings.updateState();
-                menuData.updateState();
+
+                const menuUpdate = menuData.updateState();
+                if (menuUpdate === 'not-ready') {
+                    await sleep(config.pollRate);
+                    continue;
+                }
 
                 // osu! calculates audioTrack length a little bit after updating menuData, sooo.. lets this thing run regardless of menuData updating
                 if (menuData.Folder !== '' && menuData.Folder !== null) {
@@ -276,7 +281,13 @@ export class OsuInstance {
                 }
 
                 // update important data before doing rest
-                if (allTimesData.Status === 7) resultsScreenData.updateState();
+                if (allTimesData.Status === 7) {
+                    const resultUpdate = resultsScreenData.updateState();
+                    if (resultUpdate === 'not-ready') {
+                        await sleep(config.pollRate);
+                        continue;
+                    }
+                }
 
                 const currentMods =
                     allTimesData.Status === 2

--- a/packages/tosu/src/objects/instanceManager/osuInstance.ts
+++ b/packages/tosu/src/objects/instanceManager/osuInstance.ts
@@ -346,7 +346,7 @@ export class OsuInstance {
 
                         if (
                             allTimesData.PlayTime <
-                            Math.min(50, beatmapPpData.timings.firstObj)
+                            Math.min(0, beatmapPpData.timings.firstObj)
                         ) {
                             gamePlayData.init(true, 'not-default');
                             break;

--- a/packages/tosu/src/objects/instanceManager/osuInstance.ts
+++ b/packages/tosu/src/objects/instanceManager/osuInstance.ts
@@ -277,6 +277,9 @@ export class OsuInstance {
                     }
                 }
 
+                // update important data before doing rest
+                if (allTimesData.Status === 7) resultsScreenData.updateState();
+
                 switch (allTimesData.Status) {
                     case 0:
                         bassDensityData.updateState();
@@ -327,7 +330,7 @@ export class OsuInstance {
                         break;
 
                     case 7:
-                        resultsScreenData.updateState();
+                        resultsScreenData.updatePerformance();
                         break;
 
                     case 22:

--- a/packages/tosu/src/objects/instanceManager/osuInstance.ts
+++ b/packages/tosu/src/objects/instanceManager/osuInstance.ts
@@ -248,8 +248,6 @@ export class OsuInstance {
         while (!this.isDestroyed) {
             try {
                 allTimesData.updateState();
-                settings.updateState();
-
                 const menuUpdate = menuData.updateState();
                 if (menuUpdate === 'not-ready') {
                     await sleep(config.pollRate);
@@ -288,6 +286,8 @@ export class OsuInstance {
                         continue;
                     }
                 }
+
+                settings.updateState();
 
                 const currentMods =
                     allTimesData.Status === 2

--- a/packages/tosu/src/objects/instanceManager/osuInstance.ts
+++ b/packages/tosu/src/objects/instanceManager/osuInstance.ts
@@ -100,6 +100,7 @@ export class OsuInstance {
     ipcId: number = 0;
 
     previousState: string = '';
+    previousMP3Length: number = 0;
     previousTime: number = 0;
 
     emitter: EventEmitter;
@@ -296,7 +297,10 @@ export class OsuInstance {
                           ? resultsScreenData.Mods
                           : allTimesData.MenuMods;
 
-                const currentState = `${menuData.MD5}:${menuData.MenuGameMode}:${currentMods}:${menuData.MP3Length}`;
+                const currentState = `${menuData.MD5}:${menuData.MenuGameMode}:${currentMods}`;
+                const updateGraph =
+                    this.previousState !== currentState &&
+                    this.previousMP3Length !== menuData.MP3Length;
                 if (
                     menuData.Path?.endsWith('.osu') &&
                     allTimesData.GameFolder &&
@@ -304,6 +308,16 @@ export class OsuInstance {
                 ) {
                     this.previousState = currentState;
                     beatmapPpData.updateMapMetadata(currentMods);
+                    beatmapPpData.updateGraph(currentMods);
+                }
+
+                if (
+                    menuData.Path?.endsWith('.osu') &&
+                    allTimesData.GameFolder &&
+                    updateGraph
+                ) {
+                    beatmapPpData.updateGraph(currentMods);
+                    this.previousMP3Length = menuData.MP3Length;
                 }
 
                 switch (allTimesData.Status) {
@@ -311,7 +325,6 @@ export class OsuInstance {
                         bassDensityData.updateState();
                         break;
 
-                    // skip editor, to prevent constant data reset
                     case 1:
                         if (this.previousTime === allTimesData.PlayTime) break;
 

--- a/packages/tosu/src/utils/converters.ts
+++ b/packages/tosu/src/utils/converters.ts
@@ -33,9 +33,5 @@ export const netDateBinaryToDate = (
     const epochTicks = 621355968000000000n;
     const milliseconds = (dateData - epochTicks) / ticksPerMillisecond;
 
-    return addTimezoneOffset(new Date(Number(milliseconds)));
+    return new Date(Number(milliseconds));
 };
-
-function addTimezoneOffset(date: Date) {
-    return new Date(date.getTime() - date.getTimezoneOffset() * 60000);
-}


### PR DESCRIPTION
- credits
- Switching to old method of pushing HitErrors
- Remove delay for non-tournament clients
- Prevent updating if one of values `not-ready`
- adjust spam factor for HitErrors
- Use `UTC+0` for `createdAt` on result screen
- fix `hitError` issue, and `null pointer`