### PR TITLE
chore: reset passedObjects before hitting first note

### DIFF
--- a/packages/tosu/src/entities/GamePlayData/index.ts
+++ b/packages/tosu/src/entities/GamePlayData/index.ts
@@ -128,6 +128,12 @@ export class GamePlayData extends AbstractEntity {
         this.Leaderboard = undefined;
     }
 
+    resetQuick() {
+        wLogger.debug('GD(resetQuick) Reset ');
+
+        this.previousPassedObjects = 0;
+    }
+
     resetKeyOverlay() {
         if (this.isKeyOverlayDefaultState) {
             return;

--- a/packages/tosu/src/objects/instanceManager/osuInstance.ts
+++ b/packages/tosu/src/objects/instanceManager/osuInstance.ts
@@ -299,7 +299,7 @@ export class OsuInstance {
 
                 const currentState = `${menuData.MD5}:${menuData.MenuGameMode}:${currentMods}`;
                 const updateGraph =
-                    this.previousState !== currentState &&
+                    this.previousState !== currentState ||
                     this.previousMP3Length !== menuData.MP3Length;
                 if (
                     menuData.Path?.endsWith('.osu') &&

--- a/packages/tosu/src/objects/instanceManager/osuInstance.ts
+++ b/packages/tosu/src/objects/instanceManager/osuInstance.ts
@@ -360,6 +360,14 @@ export class OsuInstance {
                             beatmapPpData.resetCurrentAttributes();
                         }
 
+                        // reset before first object
+                        if (
+                            allTimesData.PlayTime <
+                            beatmapPpData.timings.firstObj
+                        ) {
+                            gamePlayData.resetQuick();
+                        }
+
                         this.previousTime = allTimesData.PlayTime;
 
                         gamePlayData.updateState();


### PR DESCRIPTION
Beginnig of this  video was broken https://www.youtube.com/watch?v=0Hwy6rV1lDg, and i suspect thats because of incorrect resetted previousPassedObjects