### PR TITLE
fix: read addresses as uint32 instead of int64

### DIFF
--- a/packages/common/utils/agruments.ts
+++ b/packages/common/utils/agruments.ts
@@ -1,9 +1,8 @@
-const regex = /(?:--|-)(?<name>[^=\s]+)(?:[= ](?<value>(?!--|-)\S*))?/g;
-
 export const argumetsParser = (argumentsString: string[] | string) => {
     const args: { [key: string]: any } = {};
 
     if (typeof argumentsString === 'string') {
+        const regex = /(?:--|-)(?<name>[^=\s]+)(?:[= ](?<value>(?!--|-)\S*))?/g;
         const matches = [...argumentsString.matchAll(regex)];
         matches.forEach((match) => {
             const name = match?.groups?.name || '';
@@ -18,6 +17,7 @@ export const argumetsParser = (argumentsString: string[] | string) => {
         return args;
     }
 
+    const regex = /(?:--|-)(?<name>[^=\s]+)(?:[= ](?<value>(?!--|-)\S*))?/;
     for (let i = 0; i < argumentsString.length; i++) {
         const arg = argumentsString[i];
 

--- a/packages/tosu/src/entities/GamePlayData/index.ts
+++ b/packages/tosu/src/entities/GamePlayData/index.ts
@@ -308,11 +308,12 @@ export class GamePlayData extends AbstractEntity {
 
             const keyOverlayPtr = process.readUInt(rulesetAddr + 0xb0);
             if (keyOverlayPtr === 0) {
-                wLogger.debug(
-                    `GD(updateKeyOverlay) keyOverlayPtr is zero [${keyOverlayPtr}] (${rulesetAddr}  -  ${patterns.getPattern(
-                        'rulesetsAddr'
-                    )})`
-                );
+                if (this.Mode !== 3 && this.Mode !== 1)
+                    wLogger.debug(
+                        `GD(updateKeyOverlay) keyOverlayPtr is zero [${keyOverlayPtr}] (${rulesetAddr}  -  ${patterns.getPattern(
+                            'rulesetsAddr'
+                        )})`
+                    );
                 return;
             }
 

--- a/packages/tosu/src/entities/GamePlayData/index.ts
+++ b/packages/tosu/src/entities/GamePlayData/index.ts
@@ -156,12 +156,14 @@ export class GamePlayData extends AbstractEntity {
 
     updateState() {
         try {
-            const { process, patterns, menuData } =
+            const { process, patterns, allTimesData, beatmapPpData, menuData } =
                 this.osuInstance.getServices([
                     'process',
                     'patterns',
                     'allTimesData',
-                    'menuData'
+                    'menuData',
+                    'allTimesData',
+                    'beatmapPpData'
                 ]);
 
             const { baseAddr, rulesetsAddr } = patterns.getPatterns([
@@ -213,24 +215,8 @@ export class GamePlayData extends AbstractEntity {
                 process.readInt(process.readInt(scoreBase + 0x1c) + 0x8);
             // [[Ruleset + 0x68] + 0x38] + 0x64
             this.Mode = process.readInt(scoreBase + 0x64);
-            // [[Ruleset + 0x68] + 0x38] + 0x68
-            this.MaxCombo = process.readShort(scoreBase + 0x68);
             // [[Ruleset + 0x68] + 0x38] + 0x78
             this.Score = process.readInt(rulesetAddr + 0x100);
-            // [[Ruleset + 0x68] + 0x38] + 0x88
-            this.Hit100 = process.readShort(scoreBase + 0x88);
-            // [[Ruleset + 0x68] + 0x38] + 0x8A
-            this.Hit300 = process.readShort(scoreBase + 0x8a);
-            // [[Ruleset + 0x68] + 0x38] + 0x8C
-            this.Hit50 = process.readShort(scoreBase + 0x8c);
-            // [[Ruleset + 0x68] + 0x38] + 0x8E
-            this.HitGeki = process.readShort(scoreBase + 0x8e);
-            // [[Ruleset + 0x68] + 0x38] + 0x90
-            this.HitKatu = process.readShort(scoreBase + 0x90);
-            // [[Ruleset + 0x68] + 0x38] + 0x92
-            this.HitMiss = process.readShort(scoreBase + 0x92);
-            // [[Ruleset + 0x68] + 0x38] + 0x94
-            this.Combo = process.readShort(scoreBase + 0x94);
             // [[Ruleset + 0x68] + 0x40] + 0x14
             this.PlayerHPSmooth = process.readDouble(hpBarBase + 0x14) || 0;
             // [[Ruleset + 0x68] + 0x40] + 0x1C
@@ -239,6 +225,25 @@ export class GamePlayData extends AbstractEntity {
             this.Accuracy = process.readDouble(
                 process.readInt(gameplayBase + 0x48) + 0xc
             );
+
+            if (allTimesData.PlayTime >= beatmapPpData.timings.firstObj - 100) {
+                // [[Ruleset + 0x68] + 0x38] + 0x88
+                this.Hit100 = process.readShort(scoreBase + 0x88);
+                // [[Ruleset + 0x68] + 0x38] + 0x8A
+                this.Hit300 = process.readShort(scoreBase + 0x8a);
+                // [[Ruleset + 0x68] + 0x38] + 0x8C
+                this.Hit50 = process.readShort(scoreBase + 0x8c);
+                // [[Ruleset + 0x68] + 0x38] + 0x8E
+                this.HitGeki = process.readShort(scoreBase + 0x8e);
+                // [[Ruleset + 0x68] + 0x38] + 0x90
+                this.HitKatu = process.readShort(scoreBase + 0x90);
+                // [[Ruleset + 0x68] + 0x38] + 0x92
+                this.HitMiss = process.readShort(scoreBase + 0x92);
+                // [[Ruleset + 0x68] + 0x38] + 0x94
+                this.Combo = process.readShort(scoreBase + 0x94);
+                // [[Ruleset + 0x68] + 0x38] + 0x68
+                this.MaxCombo = process.readShort(scoreBase + 0x68);
+            }
 
             if (this.MaxCombo > 0) {
                 const baseUR = this.calculateUR();

--- a/packages/tosu/src/entities/TourneyUserProfileData/index.ts
+++ b/packages/tosu/src/entities/TourneyUserProfileData/index.ts
@@ -31,8 +31,6 @@ export class TourneyUserProfileData extends AbstractEntity {
     }
 
     updateState() {
-        wLogger.debug('TUPD(updateState) Starting');
-
         const { process, gamePlayData, patterns } =
             this.osuInstance.getServices([
                 'process',
@@ -47,7 +45,8 @@ export class TourneyUserProfileData extends AbstractEntity {
             wLogger.debug('TUPD(updateState) Slot is not equiped');
 
             this.resetState();
-            gamePlayData.init(undefined, 'tourney');
+            if (gamePlayData.isDefaultState !== true)
+                gamePlayData.init(undefined, 'tourney');
             return;
         }
 
@@ -86,7 +85,5 @@ export class TourneyUserProfileData extends AbstractEntity {
             );
             wLogger.debug(exc);
         }
-
-        wLogger.debug('TUPD(updateState) updated');
     }
 }

--- a/packages/tosu/src/objects/instanceManager/osuInstance.ts
+++ b/packages/tosu/src/objects/instanceManager/osuInstance.ts
@@ -384,7 +384,10 @@ export class OsuInstance {
                         break;
 
                     default:
-                        gamePlayData.init(undefined, 'default');
+                        gamePlayData.init(
+                            undefined,
+                            `default-${allTimesData.Status}`
+                        );
                         resultsScreenData.init();
                         break;
                 }

--- a/packages/tsprocess/lib/functions.cc
+++ b/packages/tsprocess/lib/functions.cc
@@ -16,7 +16,7 @@ Napi::Value read_byte(const Napi::CallbackInfo &args) {
   }
 
   auto handle = reinterpret_cast<void *>(args[0].As<Napi::Number>().Int64Value());
-  auto address = args[1].As<Napi::Number>().Uint32Value();
+  auto address = args[1].As<Napi::Number>().Int64Value();
   auto result = memory::read<int8_t>(handle, address);
   if (!std::get<1>(result)) {
     Napi::TypeError::New(env, logger::format("Couldn't read byte at %x", address)).ThrowAsJavaScriptException();
@@ -355,7 +355,7 @@ Napi::Value read_csharp_string(const Napi::CallbackInfo &args) {
       )) {
 #ifdef _WIN32
     auto error_str = logger::format(
-      "Couldn't read C# string length (base: %x, length: %x %d, last error: %d)", address, address + sizeof(int),
+      "Couldn't read C# string length (base: %x, length: %x, last error: %d)", address, address + sizeof(int),
       GetLastError(), reinterpret_cast<void *>(address)
     );
 #else

--- a/packages/tsprocess/lib/functions.cc
+++ b/packages/tsprocess/lib/functions.cc
@@ -355,8 +355,7 @@ Napi::Value read_csharp_string(const Napi::CallbackInfo &args) {
       )) {
 #ifdef _WIN32
     auto error_str = logger::format(
-      "Couldn't read C# string length (base: %x, length: %x, last error: %d)", address, address + sizeof(int),
-      GetLastError(), reinterpret_cast<void *>(address)
+      "Couldn't read C# string length (base: %x, length: %x, last error: %d)", address, address + sizeof(int), GetLastError()
     );
 #else
     auto error_str = logger::format("Couldn't read C# string length (base: %x)", address);

--- a/packages/tsprocess/lib/functions.cc
+++ b/packages/tsprocess/lib/functions.cc
@@ -16,7 +16,7 @@ Napi::Value read_byte(const Napi::CallbackInfo &args) {
   }
 
   auto handle = reinterpret_cast<void *>(args[0].As<Napi::Number>().Int64Value());
-  auto address = args[1].As<Napi::Number>().Int64Value();
+  auto address = args[1].As<Napi::Number>().Uint32Value();
   auto result = memory::read<int8_t>(handle, address);
   if (!std::get<1>(result)) {
     Napi::TypeError::New(env, logger::format("Couldn't read byte at %x", address)).ThrowAsJavaScriptException();

--- a/packages/tsprocess/lib/functions.cc
+++ b/packages/tsprocess/lib/functions.cc
@@ -16,7 +16,7 @@ Napi::Value read_byte(const Napi::CallbackInfo &args) {
   }
 
   auto handle = reinterpret_cast<void *>(args[0].As<Napi::Number>().Int64Value());
-  auto address = args[1].As<Napi::Number>().Int64Value();
+  auto address = args[1].As<Napi::Number>().Uint32Value();
   auto result = memory::read<int8_t>(handle, address);
   if (!std::get<1>(result)) {
     Napi::TypeError::New(env, logger::format("Couldn't read byte at %x", address)).ThrowAsJavaScriptException();
@@ -33,7 +33,7 @@ Napi::Value read_short(const Napi::CallbackInfo &args) {
   }
 
   auto handle = reinterpret_cast<void *>(args[0].As<Napi::Number>().Int64Value());
-  auto address = args[1].As<Napi::Number>().Int64Value();
+  auto address = args[1].As<Napi::Number>().Uint32Value();
   auto result = memory::read<int16_t>(handle, address);
   if (!std::get<1>(result)) {
     Napi::TypeError::New(env, logger::format("Couldn't read short at %x", address)).ThrowAsJavaScriptException();
@@ -50,7 +50,7 @@ Napi::Value read_int(const Napi::CallbackInfo &args) {
   }
 
   auto handle = reinterpret_cast<void *>(args[0].As<Napi::Number>().Int64Value());
-  auto address = args[1].As<Napi::Number>().Int64Value();
+  auto address = args[1].As<Napi::Number>().Uint32Value();
   auto result = memory::read<int32_t>(handle, address);
   if (!std::get<1>(result)) {
     Napi::TypeError::New(env, logger::format("Couldn't read int at %x", address)).ThrowAsJavaScriptException();
@@ -67,7 +67,7 @@ Napi::Value read_uint(const Napi::CallbackInfo &args) {
   }
 
   auto handle = reinterpret_cast<void *>(args[0].As<Napi::Number>().Int64Value());
-  auto address = args[1].As<Napi::Number>().Int64Value();
+  auto address = args[1].As<Napi::Number>().Uint32Value();
   auto result = memory::read<uint32_t>(handle, address);
   if (!std::get<1>(result)) {
     Napi::TypeError::New(env, logger::format("Couldn't read uint at %x", address)).ThrowAsJavaScriptException();
@@ -84,7 +84,7 @@ Napi::Value read_float(const Napi::CallbackInfo &args) {
   }
 
   auto handle = reinterpret_cast<void *>(args[0].As<Napi::Number>().Int64Value());
-  auto address = args[1].As<Napi::Number>().Int64Value();
+  auto address = args[1].As<Napi::Number>().Uint32Value();
   auto result = memory::read<float>(handle, address);
   if (!std::get<1>(result)) {
     Napi::TypeError::New(env, logger::format("Couldn't read float at %x", address)).ThrowAsJavaScriptException();
@@ -101,7 +101,7 @@ Napi::Value read_long(const Napi::CallbackInfo &args) {
   }
 
   auto handle = reinterpret_cast<void *>(args[0].As<Napi::Number>().Int64Value());
-  auto address = args[1].As<Napi::Number>().Int64Value();
+  auto address = args[1].As<Napi::Number>().Uint32Value();
   auto result = memory::read<int64_t>(handle, address);
   if (!std::get<1>(result)) {
     Napi::TypeError::New(env, logger::format("Couldn't read long at %x", address)).ThrowAsJavaScriptException();
@@ -118,7 +118,7 @@ Napi::Value read_double(const Napi::CallbackInfo &args) {
   }
 
   auto handle = reinterpret_cast<void *>(args[0].As<Napi::Number>().Int64Value());
-  auto address = args[1].As<Napi::Number>().Int64Value();
+  auto address = args[1].As<Napi::Number>().Uint32Value();
   auto result = memory::read<double>(handle, address);
   if (!std::get<1>(result)) {
     Napi::TypeError::New(env, logger::format("Couldn't read double at %x", address)).ThrowAsJavaScriptException();
@@ -204,7 +204,7 @@ Napi::Value read_buffer(const Napi::CallbackInfo &args) {
   }
 
   auto handle = reinterpret_cast<void *>(args[0].As<Napi::Number>().Int64Value());
-  auto address = args[1].As<Napi::Number>().Int64Value();
+  auto address = args[1].As<Napi::Number>().Uint32Value();
   auto size = args[2].As<Napi::Number>().Uint32Value();
   auto buffer = new uint8_t[size];
   auto data = (uint8_t *)malloc(sizeof(uint8_t) * size);
@@ -343,7 +343,7 @@ Napi::Value read_csharp_string(const Napi::CallbackInfo &args) {
   }
 
   void *handle = reinterpret_cast<void *>(args[0].As<Napi::Number>().Int64Value());
-  uintptr_t address = args[1].As<Napi::Number>().Int64Value();
+  auto address = args[1].As<Napi::Number>().Uint32Value();
 
   if (address == 0) {
     return Napi::String::New(env, "");
@@ -353,7 +353,16 @@ Napi::Value read_csharp_string(const Napi::CallbackInfo &args) {
   if (!memory::read_buffer(
         handle, address + sizeof(int), sizeof(string_length), reinterpret_cast<uint8_t *>(&string_length)
       )) {
-    Napi::TypeError::New(env, "Couldn't read C# string length").ThrowAsJavaScriptException();
+#ifdef _WIN32
+    auto error_str = logger::format(
+      "Couldn't read C# string length (base: %x, length: %x %d, last error: %d)", address, address + sizeof(int),
+      GetLastError(), reinterpret_cast<void *>(address)
+    );
+#else
+    auto error_str = logger::format("Couldn't read C# string length (base: %x)", address);
+#endif
+
+    Napi::TypeError::New(env, error_str.c_str()).ThrowAsJavaScriptException();
     return env.Null();
   }
 


### PR DESCRIPTION
this pr fixes issues when some addresses were negative when converted from int64 to unsigned version
so this just reads all addresses coming from node as uint32 instead, this shouldn't be an issue unless we plan to add lazer support