### PR TITLE
Fixes setting game folder on certain linux osu-winello configurations

### DIFF
--- a/packages/tsprocess/src/process.ts
+++ b/packages/tsprocess/src/process.ts
@@ -45,6 +45,17 @@ export class Process {
             return pathDirname(ProcessUtils.getProcessPath(this.handle));
         }
 
+        // If using osu-winello
+        if (
+            process.platform === 'linux' &&
+            this.getProcessPath().match('wine-preloader')
+        ) {
+            return this.getProcessCommandLine()
+                .slice(2)
+                .replace(/\\/g, '/')
+                .replace(/\/osu!.exe$/, ''); // Format windows dir to linux style.
+        }
+
         return this.getProcessCwd();
     }
 
@@ -54,6 +65,10 @@ export class Process {
 
     getProcessCwd(): string {
         return ProcessUtils.getProcessCwd(this.handle);
+    }
+
+    getProcessPath(): string {
+        return ProcessUtils.getProcessPath(this.handle);
     }
 
     readByte(address: number): number {


### PR DESCRIPTION
When using a wine layer for osu! on Linux, cwd doesn't fetch the osu! game folder correctly. Instead now gets the executable directory from the cmdline and formats it to be in Linux directory. Fixes #177